### PR TITLE
Add support for old version of ssh-keygen

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -219,6 +219,14 @@ setConfigFromTritonENV() {
             foundKey=true
             break
         fi
+        # old version of ssh-keygen, defaults to md5
+        if [ "$(ssh-keygen -l -f ~/.ssh/joyentc_id_rsa | awk '{print $2}' | grep ^SHA256)" == "" ]; then
+            if [[ "$(ssh-keygen -l -f ~/.ssh/$(echo $f | sed 's/.pub$//') 2> /dev/null | awk '{print $2}')" == "$SDC_KEY_ID" ]]; then
+                echo "SDC_KEY=\"~/.ssh/$(echo $f | sed 's/.pub$//')\"" >> config
+                foundKey=true
+                break
+            fi
+        fi
     done
     if ! "$foundKey" ; then
         echo "error: couldn't find the ssh key associated with fingerprint $SDC_KEY_ID in ~/.ssh/ directory..."


### PR DESCRIPTION
Older version of `ssh-keygen -l -f filename` provided the key fingerprint. #8
New version does the same with `ssh-keygen -l -E md5 -f filename`.